### PR TITLE
Revert "Patches issues #4"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ protobuf==3.20
 pytorch-lightning>=1.8.0
 rich==13.6
 scipy>=1.10
-sentencepiece
+sentencepiece==0.2.0
 spacy>=3.7
 transformers>=4.34
 wandb==0.20.1

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "transformers>=4.34",
         "spacy>=3.7.2",
         "jsonlines==4.0.0",
-        "sentencepiece==0.2.1",
+        "sentencepiece==0.2.0",
         "protobuf==3.20",
         "nltk==3.8.1",
         "scipy>=1.10",

--- a/xcore/models/xcore_model.py
+++ b/xcore/models/xcore_model.py
@@ -11,10 +11,10 @@ from xcore.models import *
 from transformers.utils.hub import cached_file as hf_cached_file
 
 class xCoRe:
-    def __init__(self, hf_name_or_path="sapienzanlp/xcore-litbank", device="cuda", weights_only=True):
+    def __init__(self, hf_name_or_path="sapienzanlp/xcore-litbank", device="cuda"):
         self.device = device
         path = self.__get_model_path__(hf_name_or_path)
-        self.model = CrossPLModule.load_from_checkpoint(path, _recursive_=False, map_location=self.device, weights_only=weights_only)
+        self.model = CrossPLModule.load_from_checkpoint(path, _recursive_=False, map_location=self.device)
         # self.model = CrossPLModule.load_from_checkpoint(hf_name_or_path, _recursive_=False, map_location=device)
         self.model = self.model.eval()
         self.model = self.model.model


### PR DESCRIPTION
Although the fix for issue #4 is correct and enables compatibility with newer versions of PyTorch and Transformers, these newer versions currently introduce additional incompatibilities when loading existing checkpoints. We are working on addressing these issues, but for now we are reverting to the legacy dependency versions to ensure the code remains executable.