### PR TITLE
Fix xCoRe always returning empty coreference clusters

### DIFF
--- a/xcore/models/model_cross.py
+++ b/xcore/models/model_cross.py
@@ -1750,7 +1750,7 @@ class xCoRe_system(torch.nn.Module):
                     preds["full_coreferences"] = [[d[(m[0], m[1])] for m in cluster] for cluster in fullcoreferences]
             else:
                 preds["full_coreferences"] = []
-        if self.cluster_representation == "soft-mc":
+        elif self.cluster_representation == "soft-mc":
             if len(mention_t_idxs) != 0:
                 start_hidden_states = torch.cat(mention_t_hs, dim=-2)
                 start_hidden_states = start_hidden_states.unsqueeze(0)
@@ -1777,7 +1777,7 @@ class xCoRe_system(torch.nn.Module):
                     preds["full_coreferences"] = [[d[(m[0], m[1])] for m in cluster] for cluster in fullcoreferences]
             else:
                 preds["full_coreferences"] = []
-        if len(coref_hs) > 0 or len(start_hs) > 0:
+        elif len(coref_hs) > 0 or len(start_hs) > 0:
             if self.cluster_representation != "s2e":
                 coref_hidden_states = torch.stack(coref_hs).squeeze(1)
                 coref_hidden_states = coref_hidden_states.unsqueeze(0)

--- a/xcore/models/xcore_model.py
+++ b/xcore/models/xcore_model.py
@@ -14,7 +14,18 @@ class xCoRe:
     def __init__(self, hf_name_or_path="sapienzanlp/xcore-litbank", device="cuda"):
         self.device = device
         path = self.__get_model_path__(hf_name_or_path)
-        self.model = CrossPLModule.load_from_checkpoint(path, _recursive_=False, map_location=self.device)
+        # PyTorch >=2.6 changed weights_only default to True, which blocks PL checkpoints
+        # that contain non-tensor globals (AttributeDict, DictConfig, etc.). Patch torch.load
+        # locally so the checkpoint loads with weights_only=False for this trusted file.
+        _orig_load = torch.load
+        def _load_unsafe(*args, **kwargs):
+            kwargs["weights_only"] = False
+            return _orig_load(*args, **kwargs)
+        try:
+            torch.load = _load_unsafe
+            self.model = CrossPLModule.load_from_checkpoint(path, _recursive_=False, map_location=self.device)
+        finally:
+            torch.load = _orig_load
         # self.model = CrossPLModule.load_from_checkpoint(hf_name_or_path, _recursive_=False, map_location=device)
         self.model = self.model.eval()
         self.model = self.model.model
@@ -190,7 +201,29 @@ class xCoRe:
             new_tokens.append(token)
 
         encoded_text = self.tokenizer(new_tokens, add_special_tokens=True, is_split_into_words=True)
-        
+
+        # transformers >= 5 changed DeBERTa tokenizer behaviour: add_special_tokens no
+        # longer inserts CLS/SEP.  The model was trained *with* CLS/SEP so we add them
+        # back manually when the tokenizer omits them.
+        if (
+            self.tokenizer.cls_token_id is not None
+            and self.tokenizer.sep_token_id is not None
+            and len(encoded_text["input_ids"]) > 0
+            and encoded_text["input_ids"][0] != self.tokenizer.cls_token_id
+        ):
+            _cls = self.tokenizer.cls_token_id
+            _sep = self.tokenizer.sep_token_id
+            _patched_word_ids = [None] + list(encoded_text.word_ids()) + [None]
+            encoded_text["input_ids"] = [_cls] + list(encoded_text["input_ids"]) + [_sep]
+            encoded_text["attention_mask"] = [1] + list(encoded_text["attention_mask"]) + [1]
+            _orig_word_to_tokens = encoded_text.word_to_tokens
+            def _shifted_word_to_tokens(word_index, batch_index=None):
+                result = _orig_word_to_tokens(word_index, batch_index)
+                if result is None:
+                    return None
+                return type(result)(result.start + 1, result.end + 1)
+            encoded_text.word_ids = lambda batch_index=None: _patched_word_ids
+            encoded_text.word_to_tokens = _shifted_word_to_tokens
 
         eos_indices = [
             encoded_text.word_to_tokens(token_to_new_token_map[eos - 1]).start


### PR DESCRIPTION
## Summary

- **Bug 1 (`model_cross.py`):** Three independent `if` blocks in the cluster-representation dispatch (lines 1732–1807) meant the final `else: preds["full_coreferences"] = []` always ran for `soft-dot` and `soft-mc` models (since `coref_hs` is always empty for those paths), silently overwriting the correctly computed result. Fixed by converting the second and third `if` to `elif`.

- **Bug 2 (`xcore_model.py`):** transformers 5.x changed the DeBERTa-v3 tokenizer so `add_special_tokens=True` no longer inserts `[CLS]`/`[SEP]` tokens. The model was trained *with* these boundary tokens, so without them the encoder produces nearly identical representations for every token and the `start_token_classifier` outputs ~0 probability for all positions (logit ≈ −14), yielding zero detected mentions and empty clusters. Fixed by detecting the missing tokens after tokenization and manually injecting them, patching `word_ids()` and `word_to_tokens()` to account for the +1 offset.

- **Bug 3 (`xcore_model.py`):** PyTorch ≥ 2.6 changed `torch.load` to use `weights_only=True` by default, which blocks PL checkpoints containing non-tensor globals (`AttributeDict`, `DictConfig`, etc.). Since PyTorch Lightning passes `weights_only` explicitly downstream, `functools.partial` cannot override it. Fixed by temporarily replacing `torch.load` with a wrapper that forces `weights_only=False` only for the duration of the checkpoint load.

## Verification

```python
from xcore import xCoRe

model = xCoRe(device="cpu")
model.model = model.model.float()
text = "Barack Obama is traveling to Rome. The city is sunny and the president plans to visit its most important attractions"
pred = model.predict(text)
# Before fix: {'clusters_token_offsets': [], 'clusters_token_text': []}
# After fix:  {'clusters_token_text': [['Rome', 'The city', 'its']]}
```

## Test plan

- [ ] Run the verification snippet above and confirm a non-empty cluster is returned
- [ ] Test with other coreference-heavy sentences (pronoun chains, named entity references)
- [ ] Verify `cross` and `long` modes still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)